### PR TITLE
YML: added github actions filters

### DIFF
--- a/.github/workflows/github-actions-iot.yml
+++ b/.github/workflows/github-actions-iot.yml
@@ -1,6 +1,11 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+      - 'bugfix/**'
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added three new filters in the github actions workflow. This filters will allow the system only run github action when a branch with names as: main, feature/ and bugfix/ receive a push.