### PR TITLE
DAL_UART: fixed wrong check to tx data size

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="767134899853239187" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1171095256565234658" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="767134899853239187" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1171095256565234658" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Application/Middleware/Drivers/Dal/dal_uart.c
+++ b/Application/Middleware/Drivers/Dal/dal_uart.c
@@ -124,10 +124,15 @@ void DAL_UartInit(void)
   */
 bool DAL_UartTx(uint8_t * data, uint16_t dataSizes, uint8_t uart)
 {
-	if ((DalUartConfig.sDalUartConfig[uart].UartHandle == NULL) || (dataSizes = 0) || (data == NULL))
+
+	if ((DalUartConfig.sDalUartConfig[uart].UartHandle == NULL) || (dataSizes == 0) || (data == NULL))
 	{
 		return false;
 	}
+
+	// Semaphore is gave for the HAL_UART_TxCpltCallback function
+	// Task using this function enters on blocked state
+	xSemaphoreTake(DalUartConfig.sDalUartConfig[uart].UartSemaphore, portMAX_DELAY);
 
 	switch(uart)
 	{
@@ -138,9 +143,6 @@ bool DAL_UartTx(uint8_t * data, uint16_t dataSizes, uint8_t uart)
 		case DAL_UART4:
 			if (HAL_UART_Transmit_IT(DalUartConfig.sDalUartConfig[uart].UartHandle, data, dataSizes) == HAL_OK)
 			{
-				// Semaphore is gave for the HAL_UART_TxCpltCallback function
-				// Task using this function enters on blocked state
-				xSemaphoreTake(DalUartConfig.sDalUartConfig[uart].UartSemaphore, portMAX_DELAY);
 				return true;
 			}
 			break;


### PR DESCRIPTION
Fixed wrong check to tx data size and fixed tx semaphore wrong position.

Semaphore was being take after tx function, giving opportunity to be take another function, using the data_uarttx, to send data over the last tranmission.